### PR TITLE
fix #171: find element description of the result in Bing + request headers

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,7 @@ blessed==1.17.8
 m2r==0.2.1
 parameterized==0.7.4
 pylint==2.5.3
-pytest==5.4.3
+pytest==6.2.5
 sphinx==3.1.2
 sphinx-rtd-theme==0.5.0
 vcrpy==4.0.2

--- a/search_engine_parser/core/engines/bing.py
+++ b/search_engine_parser/core/engines/bing.py
@@ -24,6 +24,14 @@ class Search(BaseSearch):
         params["FORM"] = "PERE"
         return params
 
+    def headers(self):
+        base_headers = super().headers()
+        base_headers.update({
+            "cookie": f"SRCHHPGUSR=SRCHLANG=en",
+            "accept-language": "en-US,en;q=0.9",
+        })
+        return base_headers
+
     def parse_soup(self, soup):
         """
         Parses Bing for a search query.
@@ -52,8 +60,10 @@ class Search(BaseSearch):
             rdict["links"] = link
 
         if return_type in (ReturnType.FULL, return_type.DESCRIPTION):
-            caption = single_result.find('div', class_='b_caption')
-            desc = caption.find('p')
+            for identifier in ({'name': 'p'}, {'name': 'div', "class_": 'b_snippetBigText'}):
+                desc = single_result.find(**identifier)
+                if desc:
+                    break
             rdict["descriptions"] = desc.text
 
         return rdict


### PR DESCRIPTION
- fixing indentifier for finding description + added a new one 
- added Bing specific headers (without them Bing returns empty results)  
- updated pytest version since the current one doesn't work with Python 3.10